### PR TITLE
Update frontend.sql

### DIFF
--- a/data/frontend.sql
+++ b/data/frontend.sql
@@ -60,11 +60,7 @@ CREATE TABLE IF NOT EXISTS `user_role` (
 -- Dumping data for table `user_role`
 --
 
-LOCK TABLES `user_role` WRITE;
-/*!40000 ALTER TABLE `user_role` DISABLE KEYS */;
 INSERT INTO `user_role` VALUES (2,'subscriber'),(1,'user');
-/*!40000 ALTER TABLE `user_role` ENABLE KEYS */;
-UNLOCK TABLES;
 
 
 --


### PR DESCRIPTION
#47 
In conjunction with the above issue, I think is better to remove the LOCK TABLE statement  from the frontend.sql file, in order to avoid suc situations. 
Various phpmyadmin versions, various Mysql GIUs can behave strange when encounter that LOCK TABLE statement 