### PR TITLE
Remove Twig/extensions and add the Translation/Date from dot-twigrenderer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "dotkernel/dot-rbac": "^3.0",
         "dotkernel/dot-rbac-guard": "^3.0",
         "dotkernel/dot-session": "^4.0",
-        "dotkernel/dot-twigrenderer": "^3.0",
+        "dotkernel/dot-twigrenderer": "^3.1.0",
         "laminas/laminas-authentication": "^2.7",
         "laminas/laminas-component-installer": "^2.1.1",
         "laminas/laminas-config-aggregator": "^1.0",
@@ -65,8 +65,7 @@
         "ramsey/uuid-doctrine": "^1.6",
         "roave/psr-container-doctrine": "^2.2",
         "robmorgan/phinx": "^0.12",
-        "tuupola/cors-middleware": "^1.1",
-        "twig/extensions": "^1.5"
+        "tuupola/cors-middleware": "^1.1"
     },
     "require-dev": {
         "laminas/laminas-development-mode": "^3.2",

--- a/config/autoload/templates.global.php
+++ b/config/autoload/templates.global.php
@@ -3,10 +3,10 @@
 use Twig\Environment;
 use Mezzio\Twig\TwigEnvironmentFactory;
 use Mezzio\Twig\TwigRendererFactory;
-use Twig\Extensions\I18nExtension;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Mezzio\Template\TemplateRendererInterface;
-use Twig\Extensions\DateExtension;
+use Dot\Twig\Extension\DateExtension;
+use Dot\Twig\Extension\TranslationExtension;
 
 return [
     'dependencies' => [
@@ -14,7 +14,7 @@ return [
             Environment::class => TwigEnvironmentFactory::class,
             TemplateRendererInterface::class => TwigRendererFactory::class,
             DateExtension::class => InvokableFactory::class,
-            I18nExtension::class => InvokableFactory::class,
+            TranslationExtension::class => InvokableFactory::class,
         ],
     ],
     'debug' => false,
@@ -29,7 +29,7 @@ return [
         'cache_dir' => 'data/cache/twig',
         'extensions' => [
             DateExtension::class,
-            I18nExtension::class
+            TranslationExtension::class
         ],
         'optimizations' => -1,
         'runtime_loaders' => [],


### PR DESCRIPTION
### Added
- Added `TranslationExtension` \ `DateExtension` form dot-twigrenderer 3.1.0 to use `trans` \ `time_diff` filter
### Removed
- Removed deprecated `twig/extensions` library 