### PR TITLE
composer removed unused package doctrine/doctrine-module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,14 @@
     "extra": {
         "laminas": {
             "component-whitelist": [
+                "laminas/laminas-httphandlerrunner"
+            ]
+        },
+        "mezzio": {
+            "component-whitelist": [
                 "mezzio/mezzio",
                 "mezzio/mezzio-helpers",
                 "mezzio/mezzio-router",
-                "laminas/laminas-httphandlerrunner",
                 "mezzio/mezzio-fastroute",
                 "mezzio/mezzio-twigrenderer"
             ]
@@ -34,7 +38,6 @@
     },
     "require": {
         "php": "^7.4",
-        "doctrine/doctrine-module": "^4.0",
         "dotkernel/dot-annotated-services": "^3.1",
         "dotkernel/dot-authorization": "^3.1",
         "dotkernel/dot-controller": "^3.1",
@@ -51,32 +54,32 @@
         "dotkernel/dot-response-header": "^3.0",
         "dotkernel/dot-session": "^4.2",
         "dotkernel/dot-twigrenderer": "^3.1.1",
-        "laminas/laminas-authentication": "^2.7",
-        "laminas/laminas-component-installer": "^2.1.1",
-        "laminas/laminas-config-aggregator": "^1.0",
-        "laminas/laminas-dependency-plugin": "^2.1",
-        "laminas/laminas-diactoros": "^2.3",
-        "laminas/laminas-form": "^2.15",
-        "laminas/laminas-i18n": "^2.10",
-        "laminas/laminas-servicemanager": "^3.4",
-        "laminas/laminas-stdlib": "^3.2",
-        "mezzio/mezzio": "^3.2",
-        "mezzio/mezzio-authorization-rbac": "^1.0",
-        "mezzio/mezzio-cors": "^1.0",
-        "mezzio/mezzio-fastroute": "^3.0",
-        "mezzio/mezzio-helpers": "^5.3",
-        "mezzio/mezzio-twigrenderer": "^2.2",
-        "ramsey/uuid-doctrine": "^1.6",
+        "laminas/laminas-authentication": "^2.8",
+        "laminas/laminas-component-installer": "^2.5",
+        "laminas/laminas-config-aggregator": "^1.6",
+        "laminas/laminas-dependency-plugin": "^2.2",
+        "laminas/laminas-diactoros": "^2.8",
+        "laminas/laminas-form": "^2.17",
+        "laminas/laminas-i18n": "^2.11",
+        "laminas/laminas-servicemanager": "^3.10",
+        "laminas/laminas-stdlib": "^3.6",
+        "mezzio/mezzio": "^3.6",
+        "mezzio/mezzio-authorization-rbac": "^1.1",
+        "mezzio/mezzio-cors": "^1.1",
+        "mezzio/mezzio-fastroute": "^3.3",
+        "mezzio/mezzio-helpers": "^5.7",
+        "mezzio/mezzio-twigrenderer": "^2.8",
+        "ramsey/uuid-doctrine": "^1.7",
         "roave/psr-container-doctrine": "^2.2",
         "robmorgan/phinx": "^0.12"
     },
     "require-dev": {
-        "laminas/laminas-development-mode": "^3.2",
-        "mezzio/mezzio-tooling": "^1.3",
+        "laminas/laminas-development-mode": "^3.4",
+        "mezzio/mezzio-tooling": "^1.4",
         "phpunit/phpunit": "^7.5",
         "roave/security-advisories": "dev-master",
-        "squizlabs/php_codesniffer": "^3.5",
-        "filp/whoops": "^2.7"
+        "squizlabs/php_codesniffer": "^3.6",
+        "filp/whoops": "^2.14"
     },
     "autoload": {
         "psr-4": {

--- a/config/config.php
+++ b/config/config.php
@@ -30,8 +30,6 @@ $aggregator = new ConfigAggregator([
         ? \Mezzio\Swoole\ConfigProvider::class
         : function(){ return[]; },
 
-    \DoctrineModule\ConfigProvider::class,
-
     // DotKernel packages
     \Dot\Mail\ConfigProvider::class,
     \Dot\Form\ConfigProvider::class,


### PR DESCRIPTION
In order to remove package `doctrine/doctrine-module` from your application, follow these steps:
1. run `composer remove doctrine/doctrine-module`
2. manually remove `\DoctrineModule\ConfigProvider::class,` from your `config/config.php` file
3. clear config cache by running `composer clear-config-cache`

This PR also bumps composer dependencies to their latest version available at this moment.