### PR TITLE
updated composer - removed laminas-form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,6 @@
         "laminas/laminas-config-aggregator": "^1.6",
         "laminas/laminas-dependency-plugin": "^2.2",
         "laminas/laminas-diactoros": "^2.8",
-        "laminas/laminas-form": "^2.17",
         "laminas/laminas-i18n": "^2.11",
         "laminas/laminas-servicemanager": "^3.10",
         "laminas/laminas-stdlib": "^3.6",


### PR DESCRIPTION
related to https://github.com/dotkernel/frontend/issues/249
_laminas/laminas-form_ can be removed
it is already required by _dotkernel/dot-form_ 