### PR TITLE
Issue #347: Fixed UndefinedInterfaceMethod issue in CookieService.

### DIFF
--- a/src/App/src/Service/CookieService.php
+++ b/src/App/src/Service/CookieService.php
@@ -4,7 +4,7 @@ namespace Frontend\App\Service;
 
 use Dot\AnnotatedServices\Annotation\Inject;
 use Dot\AnnotatedServices\Annotation\Service;
-use Laminas\Session\Config\ConfigInterface;
+use Laminas\Session\Config\StandardConfig;
 use Laminas\Session\SessionManager;
 
 /**
@@ -15,7 +15,7 @@ use Laminas\Session\SessionManager;
  */
 class CookieService implements CookieServiceInterface
 {
-    private ConfigInterface $sessionConfig;
+    private StandardConfig $sessionConfig;
 
     /**
      * @param SessionManager $sessionManager


### PR DESCRIPTION
**Note:**
With this fix, `$this->sessionConfig->getCookieSameSite()` is correctly identified on line 69, but the IDE reports a warning on the property definition (`$this->sessionConfig = $sessionManager->getConfig();`) itself:
```
Incompatible types: Expected property of type '\Laminas\Session\Config\StandardConfig', '\Laminas\Session\Config\ConfigInterface|null' provided
```
`Laminas\Session\Config\StandardConfig` does implement `Laminas\Session\Config\ConfigInterface`, that's why Psalm does not report this as an issue.