### PR TITLE
Issue #484: Show correct message when user tries to register with a deleted account email

### DIFF
--- a/src/User/src/Repository/UserRepository.php
+++ b/src/User/src/Repository/UserRepository.php
@@ -13,6 +13,9 @@ use Frontend\User\Entity\User;
 use Frontend\User\Entity\UserRememberMe;
 use Ramsey\Uuid\Uuid;
 
+use function is_string;
+use function strlen;
+
 /**
  * @extends EntityRepository<object>
  */
@@ -50,9 +53,8 @@ class UserRepository extends EntityRepository
 
         $qb->select('user')
             ->from(User::class, 'user')
-            ->where('user.identity = :email')->setParameter('email', $email)
-            ->andWhere('user.isDeleted = :isDeleted')->setParameter('isDeleted', User::IS_DELETED_NO);
-        if (! empty($uuid)) {
+            ->where('user.identity = :email')->setParameter('email', $email);
+        if (is_string($uuid) && strlen($uuid) > 0) {
             $uuid = Uuid::fromString($uuid)->getBytes();
             $qb->andWhere('user.uuid != :uuid')->setParameter('uuid', $uuid);
         }

--- a/src/User/src/Service/UserService.php
+++ b/src/User/src/Service/UserService.php
@@ -250,9 +250,7 @@ class UserService implements UserServiceInterface
 
     public function exists(string $email = '', ?string $uuid = ''): bool
     {
-        return ! empty(
-            $this->userRepository->exists($email, $uuid)
-        );
+        return $this->userRepository->exists($email, $uuid) instanceof User;
     }
 
     /**


### PR DESCRIPTION
The fix consists of removing this line from `src/User/src/Repository/UserRepository.php`:

```php
->andWhere('user.isDeleted = :isDeleted')->setParameter('isDeleted', User::IS_DELETED_NO)
```

The rest of the modifications are just small tweaks to make Psalm happy.